### PR TITLE
Disable gzip response

### DIFF
--- a/proxy.php
+++ b/proxy.php
@@ -64,7 +64,10 @@ class Proxy
         @curl_setopt($this->ch, CURLOPT_FOLLOWLOCATION, true);
         curl_setopt($this->ch, CURLOPT_MAXREDIRS, 10);
         curl_setopt($this->ch, CURLOPT_USERAGENT, 'Opera/9.23 (Windows NT 5.1; U; en)');
-        
+
+        // TPB is returning a gzipped body, force uncompressed
+        curl_setopt($this->ch, CURLOPT_ENCODING, 'identity');
+
         // URL without proxy.php
         $this->baseUrl = substr($_SERVER['PHP_SELF'], 0, -9);
     }


### PR DESCRIPTION
TPB is returning gzip-compressed responses, but the script is not gzdecode()-ing. Since some older implementations of PHP are actually missing gzdecode(), returning a non-gzipped body will work around it.
