### PR TITLE
Fix preg_replace /e modifier deprecated on PHP 5.5.x

### DIFF
--- a/proxy.php
+++ b/proxy.php
@@ -148,7 +148,7 @@ class Proxy
         $fields = explode("\r\n", preg_replace('/\x0D\x0A[\x09\x20]+/', ' ', $header));
         foreach( $fields as $field ) {
             if( preg_match('/([^:]+): (.+)/m', $field, $match) ) {
-                $match[1] = preg_replace('/(?<=^|[\x09\x20\x2D])./e', 'strtoupper("\0")', strtolower(trim($match[1])));
+                $match[1] = preg_replace_callback('/(?<=^|[\x09\x20\x2D])./', function($m) { return strtoupper($m[0]); }, strtolower(trim($match[1])));
                 if( isset($retVal[$match[1]]) ) {
                     $retVal[$match[1]] = array($retVal[$match[1]], $match[2]);
                 } else {


### PR DESCRIPTION
preg_replace() /e modifier got deprecated  PHP 5.5.x
http://php.net/manual/en/migration55.deprecated.php
